### PR TITLE
stdlib-list 0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,27 +9,38 @@ source:
   sha256: a1e503719720d71e2ed70ed809b385c60cd3fb555ba7ec046b96360d30b16d9f
 
 build:
-  number: 2
-  noarch: python
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
-    - python >=3
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3
-    - sphinx
+    - python
+    # sphinx is needed in https://github.com/jackmaney/python-stdlib-list/blob/v0.8.0/stdlib_list/fetch.py
+    # but not required for runtime and testing.
+    #- sphinx
 
 test:
   imports:
     - stdlib_list
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://github.com/jackmaney/python-stdlib-list
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
-  summary: A list of Python Standard Libraries (2.6-7, 3.2-5)
+  summary: A list of Python Standard Libraries (2.6-7, 3.2-9)
+  description: |
+    This package includes lists of all of the standard libraries for Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, and 3.9 
+    along with the code for scraping the official Python docs to get said lists.
   dev_url: http://github.com/jackmaney/python-stdlib-list
   doc_url: https://jackmaney.github.io/python-stdlib-list
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.0" %}
+{% set version = "0.8.0" %}
 
 package:
   name: stdlib-list
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/stdlib-list/stdlib-list-{{ version }}.tar.gz
-  sha256: 66c1c1724a12667cdb35be9f43181c3e6646c194e631efaaa93c1f2c2c7a1f7f
+  sha256: a1e503719720d71e2ed70ed809b385c60cd3fb555ba7ec046b96360d30b16d9f
 
 build:
   number: 2


### PR DESCRIPTION
Releases: https://github.com/jackmaney/python-stdlib-list/releases
License: https://github.com/jackmaney/python-stdlib-list/blob/v0.8.0/LICENSE
Requirements: 
- https://github.com/jackmaney/python-stdlib-list/blob/v0.8.0/setup.py
- https://github.com/jackmaney/python-stdlib-list/blob/v0.8.0/requirements.txt

Actions:

- Reset build number

- Fix python in host and run

Add missing setuptools and wheel to host

- Comment sphinx as it's not needed for runtime

- Add pip check

- Add license_family

- Fix summary

- Add description