### PR TITLE
stdlib-list 0.12.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,34 +1,38 @@
-{% set version = "0.10.0" %}
+{% set name = "stdlib-list" %}
+{% set version = "0.12.0" %}
 
 package:
-  name: stdlib-list
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/s/stdlib_list/stdlib_list-{{ version }}.tar.gz
-  sha256: 6519c50d645513ed287657bfe856d527f277331540691ddeaf77b25459964a14
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name|replace("-", "_") }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 517824f27ee89e591d8ae7c1dd9ff34f672eae50ee886ea31bb8816d77535675
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
-  skip: True  # [py<37]
+  skip: True  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
+    - pip
     - python
     - flit-core >=3.2,<4
-    - pip
-
   run:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - stdlib_list
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://pypi.org/project/stdlib-list/


### PR DESCRIPTION
stdlib-list 0.12.0 

**Destination channel:** Defaults

### Links

- [PKG-10341]
- dev_url:        https://github.com/pypi/stdlib-list//tree/v0.12.0
- conda_forge:    https://github.com/conda-forge/stdlib-list-feedstock
- pypi:           https://pypi.org/project/stdlib-list/0.12.0
- pypi inspector: https://inspector.pypi.io/project/stdlib-list/0.12.0

### Explanation of changes:

- new version number
- added tests


[PKG-10341]: https://anaconda.atlassian.net/browse/PKG-10341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ